### PR TITLE
Feature/effort chart

### DIFF
--- a/assets/css/responsiveStyles.css
+++ b/assets/css/responsiveStyles.css
@@ -29,27 +29,23 @@
 /* Custom styling for Difficulty Chart items */
 #luckChartInfo {
   display: flex;
-  margin-left: 20px;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin: 10px 20px 20px 20px;
 }
-.luckItemTotal {
-  font-size: 26px !important;
-  font-weight: bold !important;
+#luckChartInfo .luckItemTitle {
+  font-size: 26px;
+  font-weight: bold;
 }
-.luckItemSub {
-  font-size: 16px !important;
-  color: #fafafa !important;
+#luckChartInfo .luckItemSub {
+  font-size: 16px;
+  color: #e0e0e0;
 }
-.luckAvg {
-  color: #7986cb
+#avgDif .luckItemSub {
+  color: #bcc2e4
 }
-.luckGood {
-  color: #81c784
-}
-.luckMed {
-  color: #ffb74d
-}
-.luckBad {
-  color: #e57373
+#avgLuck .luckItemSub {
+  color: #bcc2e4
 }
 
 /* xl */
@@ -105,6 +101,12 @@
 @media screen and (max-width: 736px) {
   .hide-sm {
     display: none
+  }
+  #luckChartInfo .luckItemWrapper {
+    width: 50%;
+  }
+  #luckChartInfo .luckItemWrapper:nth-of-type(n+3) {
+    margin-top: 20px;
   }
 }
 
@@ -166,5 +168,11 @@
 @media screen and (max-width: 360px) {
   .hide-tiny {
     display: none
+  }
+  #luckChartInfo .luckItemWrapper {
+    width: 100%;
+  }
+  #luckChartInfo .luckItemWrapper:nth-of-type(n+1) {
+    margin-top: 20px;
   }
 }

--- a/assets/css/responsiveStyles.css
+++ b/assets/css/responsiveStyles.css
@@ -23,6 +23,32 @@
   width: 100%;
 }
 
+/* Custom styling for Difficulty Chart items */
+#luckChartInfo {
+  display: flex;
+  margin-left: 20px;
+}
+.luckItemTotal {
+  font-size: 26px !important;
+  font-weight: bold !important;
+}
+.luckItemSub {
+  font-size: 16px !important;
+  color: #fafafa !important;
+}
+.luckAvg {
+  color: #7986cb
+}
+.luckGood {
+  color: #81c784
+}
+.luckMed {
+  color: #ffb74d
+}
+.luckBad {
+  color: #e57373
+}
+
 /* xl */
 @media screen and (max-width: 1680px) {
   .hide-xl {

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
 <meta name="theme-color" content="#ffffff">
 
 <link rel="stylesheet" type="text/css" href="style.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.css" integrity="sha512-/zs32ZEJh+/EO2N1b0PEdoA10JkdC3zJ8L5FTiQu82LR9S/rOQNfQN7U59U9BC12swNeRAz3HSzIL2vpp4fv3w==" crossorigin="anonymous" />
 <link rel="stylesheet" href="assets/css/main.css" />
 <link rel="stylesheet" href="assets/css/responsiveStyles.css" />
 
@@ -30,6 +31,8 @@
 
   gtag('config', 'G-SVRD7VG6ND');
 </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.js" integrity="sha512-d9xgZrVZpmmQlfonhQUvTR7lMPtO7NkZMkA0ABN3PHCbKA5nqylQ/yWlFAyY6hYgdF1Qh6nYiuADWwKB4C2WSw==" crossorigin="anonymous"></script>
+
 <style>
 	.miner {
 		display:none;

--- a/index.html
+++ b/index.html
@@ -32,7 +32,8 @@
   gtag('config', 'G-SVRD7VG6ND');
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.js" integrity="sha512-d9xgZrVZpmmQlfonhQUvTR7lMPtO7NkZMkA0ABN3PHCbKA5nqylQ/yWlFAyY6hYgdF1Qh6nYiuADWwKB4C2WSw==" crossorigin="anonymous"></script>
-
+<script src="https://cdn.jsdelivr.net/npm/moment@2.27.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@0.1.1"></script>
 <style>
 	.miner {
 		display:none;

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
 <script src="https://cdn.jsdelivr.net/npm/moment@2.27.0"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@0.1.1"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-annotation/0.5.7/chartjs-plugin-annotation.js"></script>
+<script src="https://cdn.rawgit.com/chartjs/Chart.js/master/samples/utils.js"></script>
 <style>
 	.miner {
 		display:none;
@@ -143,7 +144,6 @@
 
 	</div>
 </section>
-
 
 <section id="wrapper">
 <!-- One -->

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.js" integrity="sha512-d9xgZrVZpmmQlfonhQUvTR7lMPtO7NkZMkA0ABN3PHCbKA5nqylQ/yWlFAyY6hYgdF1Qh6nYiuADWwKB4C2WSw==" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/moment@2.27.0"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@0.1.1"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-annotation/0.5.7/chartjs-plugin-annotation.js"></script>
 <style>
 	.miner {
 		display:none;

--- a/index.html
+++ b/index.html
@@ -34,8 +34,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.js" integrity="sha512-d9xgZrVZpmmQlfonhQUvTR7lMPtO7NkZMkA0ABN3PHCbKA5nqylQ/yWlFAyY6hYgdF1Qh6nYiuADWwKB4C2WSw==" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/moment@2.27.0"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@0.1.1"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-annotation/0.5.7/chartjs-plugin-annotation.js"></script>
-<script src="https://cdn.rawgit.com/chartjs/Chart.js/master/samples/utils.js"></script>
 <style>
 	.miner {
 		display:none;

--- a/script.js
+++ b/script.js
@@ -981,7 +981,7 @@ function Navigate(tar){
 			m += ' short';
 			if (tar != 'coins' && tar != 'help') {
 				if (tar ==='luck') {
-					h+= '<div class="LR85 clearfix"><div id="LuckChartWrapper" class="C3'+mde+' txtmed"><div id="luckChartInfo"></div><canvas id="luckChart" width="400" height="200"></canvas></div></div>';
+					h+= '<div class="LR85 clearfix"><div id="LuckChartWrapper" class="C3'+mde+' txtmed"><div id="luckChartInfo"></div><canvas id="luckChart"></canvas></div></div>';
 				} else {
 					h += '<div class="LR85 clearfix"><div id="PageTopL" class="C3'+mde+' txtmed"></div><div id="PageTopR" class="right"></div></div>';
 				}
@@ -1660,7 +1660,7 @@ function dta_Luck(){
 		let currentDif = Math.floor($D.poolstats.currentEfforts[$D.poolstats.activePort] / $D.netstats.difficulty * 100)
 		api('blocks', 1, 100).then(function(){
 			const dateFormat = 'DD-MM-YYYY'
-			const earliestDate = moment().subtract(30,'days')
+			const earliestDate = window.width > 641 ? moment().subtract(30,'days') : moment().subtract(15,'days')
 			// Average Luck
 			var eff = 0, bnum = 0;
 			if ($D.blocks[1]) $D.blocks[1].forEach(function(b) { eff += b.shares / b.diff; ++ bnum; });
@@ -1701,7 +1701,7 @@ function dta_Luck(){
 									],
 									type:'line',
 									fill:false,
-									borderColor:currentDif > 100 ? '#d32f2f' : currentDif > 50 ? '#f57c00' : '#388e3c',
+									borderColor:LuckColors(currentDif),
 									borderWidth:1,
 									pointRadius:0
 								},
@@ -1719,7 +1719,7 @@ function dta_Luck(){
 									],
 									type:'line',
 									fill:false,
-									borderColor:'#3f51b5',
+									borderColor:'#bcc2e4',
 									borderWidth:1,
 									pointRadius:0
 								}
@@ -1783,9 +1783,13 @@ function dta_Luck(){
 							},
 							}
 						},
+						aspectRatio: window.width > 641 ? 2 : 1
 				}
 			});
-			document.getElementById('luckChartInfo').innerHTML = MakeDifItem('avgDif',eff_perc,'Average Difficulty') + MakeDifItem('curDif',currentDif,'Current Effort')
+			document.getElementById('luckChartInfo').innerHTML = MakeDifItem('avgDif',eff_perc + '%','Average Difficulty',LuckColors(eff_perc)) 
+			+ MakeDifItem('avgLuck',CheckLuck(eff_perc),'Average Luck',LuckColors(eff_perc))
+			+ MakeDifItem('curDif',currentDif + '%','Current Effort',LuckColors(currentDif))
+			+ MakeDifItem('curLuck',CheckLuck(currentDif),'Current Luck',LuckColors(currentDif))
 		})
 
 		document.getElementById('PageBot').innerHTML = null;
@@ -2706,6 +2710,37 @@ function getCookie(n){
 function delCookie(n){   
     document.cookie = n+'=; Max-Age=-99999999;';  
 }
-function MakeDifItem(id,val,sub){
-	return '<div id="' + id + '" class="luckItemWrapper"><div class="luckItemTitle">' + val + '</div><div class="luckItemSub">' + sub + '</div></div>'
+function MakeDifItem(id,val,sub,cl){
+	return '<div id="' + id + '" class="luckItemWrapper"><div class="luckItemTitle" style="color:' + cl + '">' + val + '</div><div class="luckItemSub">' + sub + '</div></div>'
+}
+function CheckLuck(val){
+	console.log(val)
+	let luckStrings = {
+		1:'Very Lucky',
+		2:'Lucky',
+		3:'Nominal Luck',
+		4:'Not Lucky',
+		5:'Unlucky',
+		6:'Very Unlucky'
+	}
+		if (val < 30) {
+			return luckStrings[1]
+		} else if (val < 60) {
+			return luckStrings[2]
+		} else if (val < 80) {
+			return luckStrings[3]
+		} else if (val < 120) {
+			return luckStrings[4]
+		} else if (val < 150) {
+			return luckStrings[5]
+		} else {
+			return luckStrings[6]
+		}
+}
+function LuckColors(val) {
+	if (val < 80) {
+		return '#81c784'
+	} else if (val < 120) {
+		return '#ffb74d'
+	} else return '#e57373'
 }

--- a/script.js
+++ b/script.js
@@ -981,7 +981,7 @@ function Navigate(tar){
 			m += ' short';
 			if (tar != 'coins' && tar != 'help') {
 				if (tar ==='luck') {
-					h+= '<div class="LR85 clearfix"><div id="LuckChartWrapper" class="C3'+mde+' txtmed"><canvas id="luckChart" width="400" height="200"></canvas></div><</div>';
+					h+= '<div class="LR85 clearfix"><div id="LuckChartWrapper" class="C3'+mde+' txtmed"><div id="luckChartInfo"></div><canvas id="luckChart" width="400" height="200"></canvas></div></div>';
 				} else {
 					h += '<div class="LR85 clearfix"><div id="PageTopL" class="C3'+mde+' txtmed"></div><div id="PageTopR" class="right"></div></div>';
 				}
@@ -1657,6 +1657,7 @@ function dta_Luck(){
 	api('poolstats').then(function(){ api('netstats').then(function(){
 		let dataPoints = []
 		let colors = []
+		let currentDif = Math.floor($D.poolstats.currentEfforts[$D.poolstats.activePort] / $D.netstats.difficulty * 100)
 		api('blocks', 1, 100).then(function(){
 			const dateFormat = 'DD-MM-YYYY'
 			const earliestDate = moment().subtract(30,'days')
@@ -1680,11 +1681,49 @@ function dta_Luck(){
 			var luckChart = new Chart(ctx, {
 					type: 'scatter',
 					data: {
-							datasets: [{
+							datasets: [
+								{
 									label: 'Blocks Found (Last 30 Days)',
 									pointBackgroundColor: colors,
 									data: dataPoints
-							}]
+								},
+								{
+									label:'Current Block Effort',
+									data:[
+										{
+											x:earliestDate,
+											y:currentDif
+										},
+										{
+											x:moment(),
+											y:currentDif
+										}
+									],
+									type:'line',
+									fill:false,
+									borderColor:currentDif > 100 ? '#d32f2f' : currentDif > 50 ? '#f57c00' : '#388e3c',
+									borderWidth:1,
+									pointRadius:0
+								},
+								{
+									label:'Average Difficulty',
+									data:[
+										{
+											x:earliestDate,
+											y:eff_perc
+										},
+										{
+											x:moment(),
+											y:eff_perc
+										}
+									],
+									type:'line',
+									fill:false,
+									borderColor:'#3f51b5',
+									borderWidth:1,
+									pointRadius:0
+								}
+							]
 					},
 					options: {
 						title: {
@@ -1707,10 +1746,6 @@ function dta_Luck(){
 										},
 										ticks: {
 											min:earliestDate,
-										// 	callback: function(value) {
-										// 		console.log(value)
-                    //     return value;
-                    // }
 										},
 										distribution:'linear',
 										position: 'bottom',
@@ -1727,7 +1762,10 @@ function dta_Luck(){
 										callback: function(value) {
 											return value + '%'
 										}
-									}
+									},
+									gridLines: {
+										display: false
+									},
 								}],
 						},
 						tooltips: {
@@ -1747,6 +1785,7 @@ function dta_Luck(){
 						},
 				}
 			});
+			document.getElementById('luckChartInfo').innerHTML = MakeDifItem('avgDif',eff_perc,'Average Difficulty') + MakeDifItem('curDif',currentDif,'Current Effort')
 		})
 
 		document.getElementById('PageBot').innerHTML = null;
@@ -2666,4 +2705,7 @@ function getCookie(n){
 }
 function delCookie(n){   
     document.cookie = n+'=; Max-Age=-99999999;';  
+}
+function MakeDifItem(id,val,sub){
+	return '<div id="' + id + '" class="luckItemWrapper"><div class="luckItemTitle">' + val + '</div><div class="luckItemSub">' + sub + '</div></div>'
 }

--- a/script.js
+++ b/script.js
@@ -1713,7 +1713,10 @@ function dta_Luck(){
                     // }
 										},
 										distribution:'linear',
-										position: 'bottom'
+										position: 'bottom',
+										gridLines: {
+											display: false
+										},
 								}],
 								yAxes: [{
 									scaleLabel: {
@@ -1725,7 +1728,7 @@ function dta_Luck(){
 											return value + '%'
 										}
 									}
-								}]
+								}],
 						},
 						tooltips: {
 							callbacks: {
@@ -1741,7 +1744,7 @@ function dta_Luck(){
 									};
 							},
 							}
-						}
+						},
 				}
 			});
 		})


### PR DESCRIPTION
### Feature - Effort Chart
This new chart is accessible via the Block Effort netstat (was previously a duplicate of the PoolHash netstat item.

**Features**
 - Displays overview of average/current difficulties and 'luck' (a subjective summary of the difficulties)
 - Charts blocks found and their difficulties over the past 30 days
 - Displays reference line on chart for average and current difficulties

**Responsive Notes**
 - The overview items will stack responsively in the browser
 - The chart will only show 15 days if screen is less than 641px
 - The chart aspect ratio will adjust from 2:1 to 1:1 if screen is less than 641px
_Note: chart resizing happens on window load, so it will not track with a dynamically resized browser window_

**Other Notes**
 - This PR implements and utilizes three new utility functions for creating the overview items and getting their luck strings/colors
 - This PR adds chart.js and moment.js as well as an adapter that utilizes moment to format dateTime values in the chart.